### PR TITLE
GitHub link addresses fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>David Heseltine // Web Developer</title>
-  <link rel="stylesheet" href="./assets/css/style.css"/>
+  <link rel="stylesheet" href="../02-Challenge/assets/css/style.css"/>
 </head>
 
 <body>
@@ -21,11 +21,11 @@
     </header>
 
     <section class="hero-banner">
-        <img src="./assets/images/02-hero-bg.jpg" alt="A wooden textured background with black and white diagonal stripes."/>
+        <img src="../02-Challenge/assets/images/02-hero-bg.jpg" alt="A wooden textured background with black and white diagonal stripes."/>
         <div class="hero-banner-overlay"></div>
 
         <div class="hero-floatBox">
-            <img src="./assets/images/hero.jpg" class="hero-floatBox-image" alt="A profile picture of the author; David Heseltine"/>
+            <img src="../02-Challenge/assets/images/hero.jpg" class="hero-floatBox-image" alt="A profile picture of the author; David Heseltine"/>
         </div>
     </section>
 
@@ -67,7 +67,7 @@
             <div class="work-flexBox">
                 <div id="work-flexBox-featured-nest" class="work-flexBox-nest">
                     <article id="surf-report" class="work-card">
-                        <img src="./assets/images/02-portfolio-1.jpg" alt="A photograph of a wall of red LEDs."/>
+                        <img src="../02-Challenge/assets/images/02-portfolio-1.jpg" alt="A photograph of a wall of red LEDs."/>
                         <div class="work-card-overlay"></div>
 
                         <div class="work-floatBox light-box">
@@ -81,7 +81,7 @@
 
                 <div class="work-flexBox-nest">
                     <article id="led-wall" class="work-card">
-                        <img src="./assets/images/02-portfolio-2.jpg" alt="A photograph of a laptop displaying a SIM card."/>
+                        <img src="../02-Challenge/assets/images/02-portfolio-2.jpg" alt="A photograph of a laptop displaying a SIM card."/>
                         <div class="work-card-overlay"></div>
 
                         <div class="work-floatBox light-box">
@@ -95,7 +95,7 @@
 
                 <div class="work-flexBox-nest">
                     <article id="calculator" class="work-card">
-                        <img src="./assets/images/02-portfolio-3.jpg" alt="An overhead photograph of a toy car on a blue and pink pastel floor."/>
+                        <img src="../02-Challenge/assets/images/02-portfolio-3.jpg" alt="An overhead photograph of a toy car on a blue and pink pastel floor."/>
                         <div class="work-card-overlay"></div>
 
                         <div class="work-floatBox light-box">
@@ -109,7 +109,7 @@
 
                 <div class="work-flexBox-nest">
                     <article id="pastel-puzzles" class="work-card">
-                        <img src="./assets/images/02-portfolio-4.jpg" alt="A photograph of surfers admiring waves. A man stands in the distance holding a surfboard."/>
+                        <img src="../02-Challenge/assets/images/02-portfolio-4.jpg" alt="A photograph of surfers admiring waves. A man stands in the distance holding a surfboard."/>
                         <div class="work-card-overlay"></div>
 
                         <div class="work-floatBox light-box">
@@ -123,14 +123,14 @@
 
                 <div class="work-flexBox-nest">
                     <article id="run-buddy" class="work-card">
-                        <img src="./assets/images/02-run-buddy.jpg" alt="A badly cropped screenshot of a webpage for a fitness scheme. There is a yellow box to enter your details."/>
+                        <img src="../02-Challenge/assets/images/02-run-buddy.jpg" alt="A badly cropped screenshot of a webpage for a fitness scheme. There is a yellow box to enter your details."/>
                         <div class="work-card-overlay"></div>
 
                         <div class="work-floatBox light-box">
                             <h3>Run Buddy</h3>
                             <p>(Deployed Week 1 Challenge)</p>
                         </div>
-                        
+
                         <a href="https://github.com/lulose/01-Challenge" target="_blank" class="work-card-link"></a>
                     </article>
                 </div>


### PR DESCRIPTION
Locally the project ran fine with linking resources such as:
> link rel="stylesheet" type="text/css" href="./assets/css/style.css"

However GitHub Pages was not functioning with said links, and was edited to be linked as:
> link rel="stylesheet" type="text/css" href="../02-Challenge/assets/css/style.css"